### PR TITLE
coinflip minor bug fix

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -1155,9 +1155,9 @@ function cookie(token, tokentype, channelid) {
         }
     );
 }
-
+ let currentBet = settings.gamble.coinflip.default_amount;
 function coinflip(token, tokentype, channelid) {
-    let currentBet = settings.gamble.coinflip.default_amount;
+   
     const maxBet = settings.gamble.coinflip.max_amount;
     request.post(
         {


### PR DESCRIPTION
move the currentBet from local variable to global variable so it does not reset after every call of the coinflip function