### PR TITLE
Fix quest problem and update socket client

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ dWdnY2Y6Ly9iY3JhLmZjYmd2c2wucGJ6L2dlbnB4LzVwc2tIZ1B4Y3hQVkVlWGxxVVhGb1kgcm90MTM=
 
 If you made a video about the farmbot, please upload it to YouTube with the hashtag #thankumid0 and let me know.
 
-<h1 align="center">OwO Farm Bot V1.0.7.9(OPEN SOURCE)(EOL)</h1>
+<h1 align="center">OwO Farm Bot V1.0.8.0(OPEN SOURCE)(EOL)</h1>
 <h1>I do not recommend using this bot until v2 is released</h1>
 <p align="center">
 

--- a/bot.js
+++ b/bot.js
@@ -3352,11 +3352,11 @@ function extrahuntcheck(token, tokentype, channelid, checknumber) {
             if (cont.includes("You found:") || cont.includes("and caught a")) {
                 if (extrawarning > 0) extrawarning -= 1;
                 triggerextrahunt();
-                if (settings.banbypass && global.extrahuntpaused) {
+                if (settings.banbypass && !global.extrahuntpaused) {
                     if (global.extrafirstrun) global.extrafirstrun = false;
                     else {
-                        bancheck(extratoken, extrachannelid);
-                        dmbancheck(extratoken, owodmextrachannelid);
+                        extrabancheck(extratoken, extrachannelid);
+                        dmextrabancheck(extratoken, owodmextrachannelid);
                     }
                 }
 
@@ -3367,11 +3367,11 @@ function extrahuntcheck(token, tokentype, channelid, checknumber) {
                 if (checknumber >= 8) {
                     extrawarning += 1;
                     triggerextrahunt();
-                    if (settings.banbypass && global.extrahuntpaused) {
+                    if (settings.banbypass && !global.extrahuntpaused) {
                         if (global.extrafirstrun) global.extrafirstrun = false;
                         else {
-                            bancheck(extratoken, extrachannelid);
-                            dmbancheck(extratoken, owodmextrachannelid);
+                            extrabancheck(extratoken, extrachannelid);
+                            dmextrabancheck(extratoken, owodmextrachannelid);
                         }
                     }
                     return;
@@ -3423,8 +3423,8 @@ function extrabattlecheck(token, tokentype, channelid, checknumber) {
                         if (settings.banbypass && global.extrahuntpaused) {
                             if (global.extrafirstrun) global.extrafirstrun = false;
                             else {
-                                bancheck(extratoken, extrachannelid);
-                                dmbancheck(extratoken, owodmextrachannelid);
+                                extrabancheck(extratoken, extrachannelid);
+                                dmextrabancheck(extratoken, owodmextrachannelid);
                             }
                         }
                         return;
@@ -3438,11 +3438,11 @@ function extrabattlecheck(token, tokentype, channelid, checknumber) {
             if (checknumber >= 8) {
                 extrawarning += 1;
                 triggerextrabattle();
-                if (settings.banbypass && !global.extrahuntpaused) {
+                if (settings.banbypass && global.extrahuntpaused) {
                     if (global.extrafirstrun) global.extrafirstrun = false;
                     else {
-                        bancheck(extratoken, extrachannelid);
-                        dmbancheck(extratoken, owodmextrachannelid);
+                        extrabancheck(extratoken, extrachannelid);
+                        dmextrabancheck(extratoken, owodmextrachannelid);
                     }
                 }
                 return;

--- a/bot.js
+++ b/bot.js
@@ -2448,7 +2448,8 @@ async function getquests(token, channelid, tokentype) {
                                 }
 
                                 if (quest.includes("Say 'owo'")) {
-                                    global.quest = false;
+                                    if (tokentype == "Main Token") global.checkquest = false;
+                                    else global.extracheckquest = false;
                                     return questsayowo(
                                         token,
                                         channelid,
@@ -2462,7 +2463,8 @@ async function getquests(token, channelid, tokentype) {
                                         "xp from hunting and battling"
                                     )
                                 ) {
-                                    global.quest = false;
+                                    if (tokentype == "Main Token") global.checkquest = false;
+                                    else global.extracheckquest = false;
                                     if (tokentype == "Main Token") global.mainquest = true;
                                     else global.extraquest = true;
                                     return xpquests(
@@ -2472,7 +2474,8 @@ async function getquests(token, channelid, tokentype) {
                                     );
                                 } else {
                                     if (quest.includes("Gamble")) {
-                                        global.quest = false;
+                                        if (tokentype == "Main Token") global.checkquest = false;
+                                        else global.extracheckquest = false;
                                         return questgamble(
                                             token,
                                             channelid,
@@ -2484,7 +2487,8 @@ async function getquests(token, channelid, tokentype) {
                                     } else if (
                                         quest.includes("Use an action command on someone")
                                     ) {
-                                        global.quest = false;
+                                        if (tokentype == "Main Token") global.checkquest = false;
+                                        else global.extracheckquest = false;
                                         return questuseactioncommand(
                                             token,
                                             channelid,
@@ -2504,7 +2508,8 @@ async function getquests(token, channelid, tokentype) {
                                             "Have a friend curse you"
                                         )
                                     ) {
-                                        global.quest = false;
+                                        if (tokentype == "Main Token") global.checkquest = false;
+                                        else global.extracheckquest = false;
                                         global.manualcurse = false;
                                         return questcurseme(
                                             extratoken,
@@ -2520,7 +2525,8 @@ async function getquests(token, channelid, tokentype) {
                                             "Have a friend pray to you"
                                         )
                                     ) {
-                                        global.quest = false; //coded by @mid0aria on github
+                                        if (tokentype == "Main Token") global.checkquest = false;
+                                        else global.extracheckquest = false; //coded by @mid0aria on github
                                         global.manualpray = false;
                                         return questprayme(
                                             extratoken,
@@ -2534,7 +2540,8 @@ async function getquests(token, channelid, tokentype) {
                                     } else if (
                                         quest.includes("Battle with a friend")
                                     ) {
-                                        global.quest = false;
+                                        if (tokentype == "Main Token") global.checkquest = false;
+                                        else global.extracheckquest = false;
                                         return questbattlefriend(
                                             token,
                                             extratoken,
@@ -2550,7 +2557,8 @@ async function getquests(token, channelid, tokentype) {
                                             "Receive a cookie from 1 friends"
                                         ) && global.cookieactive
                                     ) {
-                                        global.quest = false;
+                                        if (tokentype == "Main Token") global.checkquest = false;
+                                        else global.extracheckquest = false;
                                         return questcookiefriend(
                                             extratoken,
                                             maintokenuserid,
@@ -2565,7 +2573,8 @@ async function getquests(token, channelid, tokentype) {
                                             "Have a friend use an action command"
                                         )
                                     ) {
-                                        global.quest = false;
+                                        if (tokentype == "Main Token") global.checkquest = false;
+                                        else global.extracheckquest = false;
                                         return questactionme(
                                             extratoken,
                                             maintokenuserid,
@@ -2649,7 +2658,8 @@ async function questsayowo(token, channelid, pro1, pro2, tokentype, questtitle) 
 
 async function xpquests(token, channelid, tokentype) {
     await delay(540000);
-    global.quest = true;
+    if (tokentype == "Main Token") global.checkquest = false;
+    else global.extracheckquest = false;
     if (tokentype == "Main Token") global.mainquest = true;
     else global.extraquest = true;
     getquests(token, channelid, tokentype);

--- a/bot.js
+++ b/bot.js
@@ -1,5 +1,5 @@
 global.love = "e<3"; // 💔
-var version = "1.0.7.9";
+var version = "1.0.8.0";
 var banversion = "0.1.10";
 //coded by @mid0aria on github
 const os = require("os");
@@ -60,8 +60,8 @@ if (prefix == (null || undefined || "")) {
     prefix = "owo";
 }
 
-global.quest = true;
-global.questtitle = "";
+global.checkquest = true;
+global.extracheckquest = true;
 
 //console.clear();
 process.title = `OwO Farm Bot 💗 Bot Version ${version} / BanBypass Version ${banversion} 💗`;
@@ -423,6 +423,9 @@ if (extratokencheck) {
                 console.log(
                     `[Extra Token] User: ${bod.username}`
                 );
+                socketio.emit("type", {
+                    type: "duo"
+                });
 
                 if (global.etoken) {
                     setTimeout(() => {
@@ -736,8 +739,11 @@ if (settings.times.intervals.pray.enable) {
 } else {
     var timeprayinterval = 303000;
 }
-if (settings.pray) {
-    setInterval(() => {
+global.manualpray = settings.pray;
+setTimeout(() => checkpray(), timeprayinterval);
+
+function checkpray() {
+    if (global.manualpray) {
         if (settings.banbypass) {
             bancheck(maintoken, mainchannelid);
             dmbancheck(maintoken, owodmmainchannelid);
@@ -750,7 +756,7 @@ if (settings.pray) {
             }
             pray(extratoken, "Extra Token", extrachannelid);
         }
-    }, timeprayinterval);
+    }
 }
 //--------------------------------CURSE-------------------------------------------------//
 if (settings.times.intervals.curse.enable) {
@@ -758,8 +764,11 @@ if (settings.times.intervals.curse.enable) {
 } else {
     var timecurseinterval = 303500;
 }
-if (settings.curse) {
-    setInterval(() => {
+global.manualcurse = settings.curse;
+setTimeout(() => checkcurse(), timecurseinterval);
+
+function checkcurse() {
+    if (global.manualcurse) {
         if (settings.banbypass) {
             bancheck(maintoken, mainchannelid);
             dmbancheck(maintoken, owodmmainchannelid);
@@ -772,7 +781,7 @@ if (settings.curse) {
             }
             curse(extratoken, "Extra Token", extrachannelid);
         }
-    }, timecurseinterval);
+    }
 }
 //--------------------------------UPGRADE-------------------------------------------------//
 if (settings.times.intervals.upgrade.enable) {
@@ -967,29 +976,40 @@ async function typing(token, channelid) {
     } else return;
 }
 
-async function updatequestssocket(p1, p2) {
-    socketio.emit("quest", {
-        quest: `${global.questtitle}`,
-        progress: `${p1} / ${p2}`,
-        date: `${new Date().getHours()}:${new Date().getMinutes()}:${new Date().getSeconds()}`,
-    });
+async function updatequestssocket(questtitle, p1, p2, tokentype) {
+    if (tokentype == "Main Token") {
+        socketio.emit("quest", {
+            quest: `${questtitle}`,
+            progress: `${p1} / ${p2}`,
+            date: `${new Date().getHours()}:${new Date().getMinutes()}:${new Date().getSeconds()}`,
+        });
+    } else {
+        socketio.emit("extraquest", {
+            quest: `${questtitle}`,
+            progress: `${p1} / ${p2}`,
+            date: `${new Date().getHours()}:${new Date().getMinutes()}:${new Date().getSeconds()}`,
+        });
+    }
 }
 
-async function updatechecklistsocket(i, e) {
-    setTimeout(() => {
+async function updatechecklistsocket(i, e, tokentype) {
+    if (tokentype == "Main Token") {
         socketio.emit("checklist", {
             name: i,
             status: e,
         });
-    }, 3000);
+    } else {
+        socketio.emit("extrachecklist", {
+            name: i,
+            status: e,
+        });
+    }
 }
 
 async function updateerrorsocket(eyl) {
-    setTimeout(() => {
-        socketio.emit("errors", {
-            error: eyl,
-        });
-    }, 3100);
+    socketio.emit("errors", {
+        error: eyl,
+    });
 }
 
 //----------------------------------------------------Main Features----------------------------------------------------//
@@ -1154,6 +1174,8 @@ function pray(token, tokentype, channelid) {
             );
         }
     );
+    await delay(timeprayinterval);
+    checkpray();
 }
 
 function curse(token, tokentype, channelid) {
@@ -1189,6 +1211,8 @@ function curse(token, tokentype, channelid) {
             );
         }
     );
+    await delay(timecurseinterval);
+    checkcurse();
 }
 
 function checklist(token, tokentype, channelid) {
@@ -1239,17 +1263,17 @@ function checklist(token, tokentype, channelid) {
                                 chalk.magenta(` [${tokentype}]`) +
                                     chalk.yellow(" Getting Checklist 🔎");
                                 if (des.includes("☑️ 🎉")) {
-                                    updatechecklistsocket("all", "✅");
+                                    updatechecklistsocket("all", "✅", tokentype);
                                     return "checklist completed";
                                 }
                                 if (des.includes("☑️ 💎")) {
-                                    updatechecklistsocket("lb", "✅");
+                                    updatechecklistsocket("lb", "✅", tokentype);
                                     if (tokentype == "Main Token")
                                         global.mainhuntdaily = true;
                                     else global.extrahuntdaily = true;
                                 }
                                 if (des.includes("☑️ ⚔")) {
-                                    updatechecklistsocket("crate", "✅");
+                                    updatechecklistsocket("crate", "✅", tokentype);
                                     if (tokentype == "Main Token")
                                         global.mainbattledaily = true;
                                     else global.extrabattledaily = true;
@@ -1258,14 +1282,18 @@ function checklist(token, tokentype, channelid) {
                                 if (des.includes("⬛ 🎁")) {
                                     daily(token, tokentype, channelid);
                                 } else {
-                                    updatechecklistsocket("daily", "✅");
+                                    updatechecklistsocket("daily", "✅", tokentype);
                                 }
                                 if (des.includes("⬛ 🍪")) {
                                     if (settings.cookie)
                                     setTimeout (() =>
                                         cookie(token, tokentype, channelid), 61000);
+                                    if (tokentype == "Extra Token")
+                                        global.cookieactive = true;
                                 } else {
-                                    updatechecklistsocket("cookie", "✅");
+                                    updatechecklistsocket("cookie", "✅", tokentype);
+                                    if (tokentype == "Extra Token")
+                                        global.cookieactive = false;
                                 }
                                 if (des.includes("⬛ 📝")) {
                                     console.log(
@@ -1275,9 +1303,9 @@ function checklist(token, tokentype, channelid) {
                                             )
                                     );
                                 } else {
-                                    updatechecklistsocket("vote", "✅");
+                                    updatechecklistsocket("vote", "✅", tokentype);
                                 }
-                                if (!des.includes("⬛ 📜")) updatechecklistsocket("quest", "✅");
+                                if (!des.includes("⬛ 📜")) updatechecklistsocket("quest", "✅", tokentype);
                             }
                         } catch (error) {
                             updateerrorsocket(
@@ -2330,15 +2358,18 @@ async function getquests(token, channelid, tokentype) {
                                 "You finished all of your quests!"
                             )
                         ) {
-                            global.quest = false;
-                            if (tokentype == "Main token")
+                            if (tokentype == "Main Token") {
                                 global.mainquest = true;
-                            else global.extraquest = true;
+                                global.checkquest = false;
+                            }
+                            else {
+                                global.extraquest = true;
+                                global.extracheckquest = false;
+                            }
                         } else {
                             var quest = cont[0].description
                                 .split("**1. ")[1]
                                 .split("**")[0];
-                            global.questtitle = `${quest}`;
                             var progress1 = cont[0].description
                                 .split("Progress: [")[1]
                                 .split("/")[0];
@@ -2347,7 +2378,7 @@ async function getquests(token, channelid, tokentype) {
                                 .split("]")[0];
 
                             if (
-                                (quest.includes("Battle") ||
+                                (quest.includes("Battle with") ||
                                     quest.includes("Have a friend curse you") ||
                                     quest.includes(
                                         "Have a friend pray to you"
@@ -2361,7 +2392,6 @@ async function getquests(token, channelid, tokentype) {
                                     quest = cont[0].description
                                         .split("**2. ")[1]
                                         .split("**")[0];
-                                    global.questtitle = `${quest}`;
                                     var progress1 = cont[0].description
                                         .split("Progress: [")[2]
                                         .split("/")[0];
@@ -2369,10 +2399,11 @@ async function getquests(token, channelid, tokentype) {
                                         .split("/")[2]
                                         .split("]")[0];
                                 } catch (error) {
-                                    global.quest = false;
+                                    if (tokentype == "Main Token") global.checkquest = false;
+                                    else global.extracheckquest = false;
                                 }
                                 if (
-                                    (quest.includes("Battle") ||
+                                    (quest.includes("Battle with") ||
                                         quest.includes(
                                             "Have a friend curse you"
                                         ) ||
@@ -2388,7 +2419,6 @@ async function getquests(token, channelid, tokentype) {
                                         quest = cont[0].description
                                             .split("**3. ")[1]
                                             .split("**")[0];
-                                        global.questtitle = `${quest}`;
                                         var progress1 = cont[0].description
                                             .split("Progress: [")[3]
                                             .split("/")[0];
@@ -2396,82 +2426,94 @@ async function getquests(token, channelid, tokentype) {
                                             .split("/")[3]
                                             .split("]")[0];
                                     } catch (error) {
-                                        global.quest = false;
+                                        if (tokentype == "Main Token") global.checkquest = false;
+                                        else global.extracheckquest = false;
                                     }
                                 }
                             }
 
-                            if (global.quest) {
-                                socketio.emit("quest", {
-                                    quest: `${global.questtitle}`,
-                                    progress: `${progress1} / ${progress2}`,
-                                    date: `${new Date().getHours()}:${new Date().getMinutes()}:${new Date().getSeconds()}`,
-                                });
+                            if (global.checkquest || global.extracheckquest) {
+                                if (tokentype == "Main Token") {
+                                    socketio.emit("quest", {
+                                        quest: `${global.questtitle}`,
+                                        progress: `${progress1} / ${progress2}`,
+                                        date: `${new Date().getHours()}:${new Date().getMinutes()}:${new Date().getSeconds()}`,
+                                    });
+                                } else {
+                                    socketio.emit("extraquest", {
+                                        quest: `${global.extraquesttitle}`,
+                                        progress: `${progress1} / ${progress2}`,
+                                        date: `${new Date().getHours()}:${new Date().getMinutes()}:${new Date().getSeconds()}`,
+                                    });
+                                }
 
-                                if (!global.etoken) {
-                                    if (quest.includes("Say 'owo'")) {
+                                if (quest.includes("Say 'owo'")) {
+                                    global.quest = false;
+                                    return questsayowo(
+                                        token,
+                                        channelid,
+                                        parseInt(progress1),
+                                        parseInt(progress2),
+                                        tokentype,
+                                        quest
+                                    );
+                                } else if (
+                                    quest.includes(
+                                        "xp from hunting and battling"
+                                    )
+                                ) {
+                                    global.quest = false;
+                                    if (tokentype == "Main Token") global.mainquest = true;
+                                    else global.extraquest = true;
+                                    return xpquests(
+                                        token,
+                                        channelid,
+                                        tokentype
+                                    );
+                                } else {
+                                    if (quest.includes("Gamble")) {
                                         global.quest = false;
-                                        return questsayowo(
+                                        return questgamble(
                                             token,
                                             channelid,
-                                            parseInt(progress1),
+                                            parseInt(progress1), //coded by @mid0aria on github
                                             parseInt(progress2),
-                                            tokentype
+                                            tokentype,
+                                            quest
                                         );
                                     } else if (
-                                        quest.includes(
-                                            "xp from hunting and battling"
-                                        )
+                                        quest.includes("Use an action command on someone")
                                     ) {
                                         global.quest = false;
-                                        if (tokentype == "Main Token")
-                                            global.mainquest = false;
-                                        else global.extraquest = false;
-                                        return xpquests(
+                                        return questuseactioncommand(
                                             token,
                                             channelid,
-                                            tokentype
+                                            parseInt(progress1), //coded by @mid0aria on github
+                                            parseInt(progress2),
+                                            tokentype,
+                                            quest
                                         );
-                                    } else {
-                                        if (tokentype == "Main Token")
-                                            global.mainquest = true;
-                                        else global.extraquest = true;
-                                        if (quest.includes("Gamble")) {
-                                            global.quest = false;
-                                            return questgamble(
-                                                token,
-                                                channelid,
-                                                parseInt(progress1), //coded by @mid0aria on github
-                                                parseInt(progress2),
-                                                tokentype
-                                            );
-                                        } else if (
-                                            quest.includes("Use an action")
-                                        ) {
-                                            global.quest = false;
-                                            return questuseactioncommand(
-                                                token,
-                                                channelid,
-                                                parseInt(progress1), //coded by @mid0aria on github
-                                                parseInt(progress2),
-                                                tokentype
-                                            );
-                                        }
-                                    }
-                                } else {
+                                    } else if (tokentype == "Main Token") global.mainnullquest = true;
+                                    else global.extranullquest = true; 
+                                    //this mean there is no quest can be done with one user
+                                }
+                                
+                                if (global.etoken) {
                                     if (
                                         quest.includes(
                                             "Have a friend curse you"
                                         )
                                     ) {
                                         global.quest = false;
+                                        global.manualcurse = false;
                                         return questcurseme(
                                             extratoken,
                                             maintokenuserid,
                                             channelid,
                                             parseInt(progress1),
                                             parseInt(progress2),
-                                            tokentype
+                                            tokentype,
+                                            quest
                                         );
                                     } else if (
                                         quest.includes(
@@ -2479,13 +2521,15 @@ async function getquests(token, channelid, tokentype) {
                                         )
                                     ) {
                                         global.quest = false; //coded by @mid0aria on github
+                                        global.manualpray = false;
                                         return questprayme(
                                             extratoken,
                                             maintokenuserid,
                                             channelid,
                                             parseInt(progress1),
                                             parseInt(progress2),
-                                            tokentype
+                                            tokentype,
+                                            quest
                                         );
                                     } else if (
                                         quest.includes("Battle with a friend")
@@ -2498,12 +2542,13 @@ async function getquests(token, channelid, tokentype) {
                                             channelid,
                                             parseInt(progress1),
                                             parseInt(progress2),
-                                            tokentype
+                                            tokentype,
+                                            quest
                                         );
                                     } else if (
                                         quest.includes(
                                             "Receive a cookie from 1 friends"
-                                        )
+                                        ) && global.cookieactive
                                     ) {
                                         global.quest = false;
                                         return questcookiefriend(
@@ -2512,9 +2557,35 @@ async function getquests(token, channelid, tokentype) {
                                             channelid,
                                             parseInt(progress1),
                                             parseInt(progress2),
-                                            tokentype
+                                            tokentype,
+                                            quest
+                                        );
+                                    } else if (
+                                        quest.includes(
+                                            "Have a friend use an action command"
+                                        )
+                                    ) {
+                                        global.quest = false;
+                                        return questactionme(
+                                            extratoken,
+                                            maintokenuserid,
+                                            channelid,
+                                            parseInt(progress1),
+                                            parseInt(progress2),
+                                            tokentype,
+                                            quest
                                         );
                                     }
+                                }
+                                //incase the grabbed quest not on the list above (can be auto completed)
+                                if (global.mainnullquest) {
+                                    return autocompletequests(
+                                        token,
+                                        channelid,
+                                        parseInt(progress1),
+                                        parseInt(progress2),
+                                        tokentype
+                                    );
                                 }
                             }
                         }
@@ -2526,7 +2597,7 @@ async function getquests(token, channelid, tokentype) {
                             ) +
                                 chalk.magenta(` [${tokentype}]`) +
                                 chalk.red("Unable to check quest❗") +
-                                chalk.white("Rechecking after 61 secs...")
+                                chalk.white("\nRechecking after 61 secs...")
                         );
                         setTimeout(() => updateerrorsocket("Rechecking Quest..."), 55000);
                         setTimeout(() => getquests(token, channelid, tokentype), 61000);
@@ -2539,7 +2610,16 @@ async function getquests(token, channelid, tokentype) {
     );
 }
 
-async function questsayowo(token, channelid, pro1, pro2, tokentype) {
+async function autocompletequests(token, channelid, tokentype) {
+    await delay(610000);
+    if (tokentype == "Main Token") {
+        getquests(token, channelid, tokentype);
+    } else {
+        extragetquests(token, channelid, tokentype);
+    }
+}
+
+async function questsayowo(token, channelid, pro1, pro2, tokentype, questtitle) {
     for (let np = pro2 - pro1; np > 0; np--) {
         request.post({
             headers: {
@@ -2555,14 +2635,15 @@ async function questsayowo(token, channelid, pro1, pro2, tokentype) {
         });
         var socketp = pro1;
         var socketpro1 = socketp++;
-        updatequestssocket(socketpro1, pro2);
+        updatequestssocket(questtitle, socketpro1, pro2, tokentype);
         await delay(32500);
         for (let sayowoelaina = 0; sayowoelaina < 4; sayowoelaina++) {
             elaina2(token, channelid);
             await delay(2000);
         }
     }
-    global.quest = true;
+    if (tokentype == "Main Token") global.checkquest = true;
+    else global.extracheckquest = true;
     getquests(token, channelid, tokentype);
 }
 
@@ -2574,7 +2655,7 @@ async function xpquests(token, channelid, tokentype) {
     getquests(token, channelid, tokentype);
 }
 
-async function questcurseme(token, userid, channelid, pro1, pro2, tokentype) {
+async function questcurseme(token, userid, channelid, pro1, pro2, tokentype, questtitle) {
     for (let np = pro2 - pro1; np > 0; np--) {
         request.post({
             headers: {
@@ -2590,14 +2671,16 @@ async function questcurseme(token, userid, channelid, pro1, pro2, tokentype) {
         });
         var socketp = pro1;
         var socketpro1 = socketp++;
-        updatequestssocket(socketpro1, pro2);
+        updatequestssocket(questtitle, socketpro1, pro2, tokentype);
         await delay(302000);
     }
-    global.quest = true;
+    if (tokentype == "Main Token") global.checkquest = true;
+    else global.extracheckquest = true;
+    if (settings.curse) global.manualcurse = true;
     getquests(token, channelid, tokentype);
 }
 
-async function questprayme(token, userid, channelid, pro1, pro2, tokentype) {
+async function questprayme(token, userid, channelid, pro1, pro2, tokentype, questtitle) {
     for (let np = pro2 - pro1; np > 0; np--) {
         request.post({
             headers: {
@@ -2613,10 +2696,12 @@ async function questprayme(token, userid, channelid, pro1, pro2, tokentype) {
         });
         var socketp = pro1;
         var socketpro1 = socketp++;
-        updatequestssocket(socketpro1, pro2);
+        updatequestssocket(questtitle, socketpro1, pro2, tokentype);
         await delay(302000);
     }
-    global.quest = true;
+    if (tokentype == "Main Token") global.checkquest = true;
+    else global.extracheckquest = true;
+    if (settings.pray) global.manualpray = true;
     getquests(token, channelid, tokentype);
 }
 
@@ -2627,7 +2712,8 @@ async function questbattlefriend(
     channelid,
     pro1,
     pro2,
-    tokentype
+    tokentype,
+    questtitle
 ) {
     for (let np = pro2 - pro1; np > 0; np--) {
         request.post({
@@ -2657,14 +2743,15 @@ async function questbattlefriend(
         });
         var socketp = pro1;
         var socketpro1 = socketp++;
-        updatequestssocket(socketpro1, pro2);
+        updatequestssocket(questtitle, socketpro1, pro2, tokentype);
         await delay(15000);
     }
-    global.quest = true;
+    if (tokentype == "Main Token") global.checkquest = true;
+    else global.extracheckquest = true;
     getquests(maintoken, channelid, tokentype);
 }
 
-async function questgamble(token, channelid, pro1, pro2, tokentype) {
+async function questgamble(token, channelid, pro1, pro2, tokentype, questtitle) {
     for (let np = pro2 - pro1; np > 0; np--) {
         request.post({
             headers: {
@@ -2680,37 +2767,38 @@ async function questgamble(token, channelid, pro1, pro2, tokentype) {
         });
         var socketp = pro1;
         var socketpro1 = socketp++;
-        updatequestssocket(socketpro1, pro2);
+        updatequestssocket(questtitle, socketpro1, pro2, tokentype);
         await delay(16000);
     }
-    global.quest = true;
+    if (tokentype == "Main Token") global.checkquest = true;
+    else global.extracheckquest = true;
     getquests(token, channelid, tokentype);
 }
 
-async function questcookiefriend(token, userid, channelid, pro1, pro2, tokentype) {
-    for (let np = pro2 - pro1; np > 0; np--) {
-        request.post({
-            headers: {
-                authorization: token,
-            },
-            url: `https://discord.com/api/v9/channels/${channelid}/messages`,
-            json: {
-                content: `owo cookie <@${userid}>`,
-                nonce: nonce(),
-                tts: false,
-                flags: 0,
-            },
-        });
-        var socketp = pro1;
-        var socketpro1 = socketp++;
-        updatequestssocket(socketpro1, pro2);
-        await delay(302000);
-    }
-    global.quest = true;
+async function questcookiefriend(token, userid, channelid, pro1, pro2, tokentype, questtitle) {
+    request.post({
+        headers: {
+            authorization: token,
+        },
+        url: `https://discord.com/api/v9/channels/${channelid}/messages`,
+        json: {
+            content: `owo cookie <@${userid}>`,
+            nonce: nonce(),
+            tts: false,
+            flags: 0,
+        },
+    });
+    var socketp = pro1;
+    var socketpro1 = socketp++;
+    updatequestssocket(questtitle, socketpro1, pro2, tokentype);
+    global.cookieactive = false;
+ 
+    if (tokentype == "Main Token") global.checkquest = true;
+    else global.extracheckquest = true;
     getquests(token, channelid, tokentype);
 }
 
-async function questuseactioncommand(token, userid, channelid, pro1, pro2, tokentype) {
+async function questuseactioncommand(token, userid, channelid, pro1, pro2, tokentype, questtitle) {
     for (let np = pro2 - pro1; np > 0; np--) {
         request.post({
             headers: {
@@ -2726,11 +2814,35 @@ async function questuseactioncommand(token, userid, channelid, pro1, pro2, token
         });
         var socketp = pro1;
         var socketpro1 = socketp++;
-        updatequestssocket(socketpro1, pro2);
+        updatequestssocket(questtitle, socketpro1, pro2, tokentype);
         await delay(7800);
     }
-    global.quest = true;
+    if (tokentype == "Main Token") global.checkquest = true;
+    else global.extracheckquest = true;
     getquests(token, channelid, tokentype);
+}
+
+async function questactionme(token, userid, channelid, pro1, pro2, tokentype, questtitle) {
+    for (let np = pro2 - pro1; np > 0; np--) {
+        request.post({
+            headers: {
+                authorization: token,
+            },
+            url: `https://discord.com/api/v9/channels/${channelid}/messages`,
+            json: {
+                content: `owo hug <@${userid}> `,
+                nonce: nonce(),
+                tts: false,
+                flags: 0,
+            },
+        });
+        var socketpro1 = pro1++
+        updatequestssocket(questtitle, socketpro1, pro2, tokentype);
+        await delay(8000);
+    }
+    if (tokentype == "Main Token") global.checkquest = true;
+    else global.extracheckquest = true;
+    getquest(token, channelid, tokentype);
 }
 
 //----------------------------------------------------BanCheck + Similar Bypass----------------------------------------------------//

--- a/utils/socket.js
+++ b/utils/socket.js
@@ -3,7 +3,7 @@ var io = socket.connect("http://localhost:1337");
 const chalk = require("chalk");
 
 console.clear();
-process.title = `Socket Client V3 / e.`;
+process.title = `Socket Client V0.0.3 / e.`;
 global.state = "";
 global.quest = "";
 global.questpr = "";

--- a/utils/socket.js
+++ b/utils/socket.js
@@ -3,12 +3,16 @@ var io = socket.connect("http://localhost:1337");
 const chalk = require("chalk");
 
 console.clear();
-process.title = `Socket Client V0.0.2 / e.`;
+process.title = `Socket Client V3 / e.`;
 global.state = "";
 global.quest = "";
 global.questpr = "";
 global.questdate = "";
+global.extraquest = "";
+global.extraquestpr = "";
+global.extraquestdate = "";
 global.times = "";
+global.sockettype = "";
 
 global.checklistdaily = `❌`;
 global.checklistvote = `❌`;
@@ -17,7 +21,18 @@ global.checklistquest = `❌`;
 global.checklistlb = `❌`;
 global.checklistcrate = `❌`;
 
+global.extrachecklistdaily = `❌`;
+global.extrachecklistvote = `❌`;
+global.extrachecklistcookie = `❌`;
+global.extrachecklistquest = `❌`;
+global.extrachecklistlb = `❌`;
+global.extrachecklistcrate = `❌`;
+
 global.eyl = "Everything okay";
+
+io.on("type", (t) => {
+    global.type = t.type;
+});
 
 io.on("connect", () => {
     console.clear();
@@ -40,6 +55,12 @@ io.on("quest", (data) => {
     global.questdate = data.date;
 });
 
+io.on("extraquest", (data) => {
+    global.extraquest = data.quest;
+    global.extraquestpr = data.progress;
+    global.extraquestdate = data.date;
+});
+
 io.on("checklist", (e) => {
     if (e.name === "all") {
         global.checklistdaily = "✅";
@@ -60,6 +81,29 @@ io.on("checklist", (e) => {
         global.checklistlb = "✅";
     } else if (e.name === "crate") {
         global.checklistcrate = "✅";
+    }
+});
+
+io.on("extrachecklist", (e) => {
+    if (e.name === "all") {
+        global.extrachecklistdaily = "✅";
+        global.extrachecklistvote = "✅";
+        global.extrachecklistcookie = "✅";
+        global.extrachecklistlb = "✅";
+        global.extrachecklistcrate = "✅";
+        global.extrachecklistquest = "✅";
+    } else if (e.name === "daily") {
+        global.extrachecklistdaily = "✅";
+    } else if (e.name === "cookie") {
+        global.extrachecklistcookie = "✅";
+    } else if (e.name === "vote") {
+        global.extrachecklistvote = "✅";
+    } else if (e.name === "quest") {
+        global.extrachecklistquest = "✅";
+    } else if (e.name === "lb") {
+        global.extrachecklistlb = "✅";
+    } else if (e.name === "crate") {
+        global.extrachecklistcrate = "✅";
     }
 });
 
@@ -86,41 +130,86 @@ setInterval(() => {
     var cq = global.checklistquest;
     var cl = global.checklistlb;
     var gc = global.checklistcrate;
-    var qst = chalk.blue("Start time: ") + chalk.red(global.questdate);
+    var qst = chalk.red("[Main] ") + chalk.blue("Start time: ") + chalk.red(global.questdate);
     var qq = chalk.yellow("Quest: ") + chalk.magenta(`${global.quest}`);
     var qpr = chalk.green("Progress: ") + chalk.yellow(global.questpr);
+    
+    var ecd = global.extrachecklistdaily;
+    var ecv = global.extrachecklistvote;
+    var ecc = global.extrachecklistcookie;
+    var ecq = global.extrachecklistquest;
+    var ecl = global.extrachecklistlb;
+    var egc = global.extrachecklistcrate;
+    var eqst = chalk.red("[Extra] ") + chalk.blue("Start time: ") + chalk.red(global.extraquestdate);
+    var eqq = chalk.yellow("Quest: ") + chalk.magenta(`${global.extraquest}`);
+    var eqpr = chalk.green("Progress: ") + chalk.yellow(global.extraquestpr);
+    
     var tms = global.times;
     if (global.eyl === "Everything okay") {
         var eyl = chalk.yellow(global.eyl);
     } else {
         var eyl = chalk.red(global.eyl);
     }
+    
+    if (global.type == "duo") global.sockettype = "Double Threaded Farm Bot!";
+    else global.sockettype = "Single Threaded Farm Bot!";
 
-    console.log(
+    if(global.type == "duo") {
+        console.log(
         `
-╔═══════════════════════════════════════════════════════════════════════════
+╔═══════════════════════════════════════════════════════════════════════════════
 ║ > Clock: ${currenttime}                                                              
 ║ > Settings: ${state} 
-║
-╠════════════════════════╦══════════════════════════════════════════════════
+║ > Type: ${global.sockettype}
+╠════════════════════════╦══════════════════════════════════════════════════════
 ║                        ║                                          
 ║ > Checklist📜          ║ > Quest🔎
 ║                        ║   
-╠════╦═══════════════════╬══════════════════════════════════════════════════
+╠════╦══════════════╦════╬══════════════════════════════════════════════════════
+║Main║              ║Ext.║ ${qst} 
+║ ${cd} ║ Daily        ║ ${ecd} ║ ${qq}
+║ ${cv} ║ Vote         ║ ${ecv} ║ ${qpr}
+║ ${cc} ║ Cookie       ║ ${ecc} ╠══════════════════════════════════════════════════════
+║ ${cq} ║ Quest        ║ ${ecq} ║ ${eqst}
+║ ${cl} ║ LootBox      ║ ${ecl} ║ ${eqq}
+║ ${gc} ║ Crate        ║ ${egc} ║ ${eqpr}
+╠════╩══════════════╩════╩══════════════════════════════════════════════════════
+║ > ⏱️ Times
+║ ${tms}
+╠═══════════════════════════════════════════════════════════════════════════════
+║ > Errors❗ 
+║ ${eyl}
+╚═══════════════════════════════════════════════════════════════════════════════
+
+`
+        );
+    } else {
+        console.log(
+        `
+╔═══════════════════════════════════════════════════════════════════════════════
+║ > Clock: ${currenttime}                                                              
+║ > Settings: ${state} 
+║ > Type: ${global.sockettype}
+╠════════════════════════╦══════════════════════════════════════════════════════
+║                        ║                                          
+║ > Checklist📜          ║ > Quest🔎
+║                        ║   
+╠════╦═══════════════════╬══════════════════════════════════════════════════════
 ║ ${cd} ║ Daily             ║ ${qst} 
 ║ ${cv} ║ Vote              ║ 
 ║ ${cc} ║ Cookie            ║ ${qq}
 ║ ${cq} ║ Quest             ║
 ║ ${cl} ║ LootBox           ║ ${qpr}
 ║ ${gc} ║ Crate             ║
-╠════════════════════════╩══════════════════════════════════════════════════
+╠════╩═══════════════════╩══════════════════════════════════════════════════════
 ║ > ⏱️ Times
 ║ ${tms}
-╠═══════════════════════════════════════════════════════════════════════════
+╠═══════════════════════════════════════════════════════════════════════════════
 ║ > Errors❗ 
 ║ ${eyl}
-╚═══════════════════════════════════════════════════════════════════════════
+╚═══════════════════════════════════════════════════════════════════════════════
 
 `
-    );
+        );
+    }
 }, 1000);

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-    "version": "1.0.7.9",
+    "version": "1.0.8.0",
     "updater": "0.0.3",
-    "note": "V1.0.7.9: Prevent first time run captcha (EOL)"
+    "note": "V1.0.8.0: Fixed quest related problem and update socket client (EOL)"
 }


### PR DESCRIPTION
Just got alt account back and when i turn on extratoken, i found a serious problem: auto quest died!
And when i take a look, it was a error in code that will not doing all the quest can be done by one account (say 'owo', gamble, use action). That mean the quest will stay the same forever.

What do i did:
Fix and make new quest mechanic
New socket client for two account mode:
    Fix problem at quest title because there is only one title variable
    Fix checklist state because there is only one checklist variable
Now the bot will stop auto pray/curse when it found a pray/curse quest no avoid confict
Fix `updatesockket` function by simply remove the timeout, now error will update correctly (old version socket error will not update when captcha is detected)
Fixed a captcha problem to extratoken (using main captcha check function instead of extra captcha check function)